### PR TITLE
Adjust URLs after project changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status]( https://ci.appveyor.com/api/projects/status/github/simplare/stoffi-player-core?branch=develop&svg=true)](https://ci.appveyor.com/project/simplare/stoffi-player-core)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/simplare/stoffi-core?branch=master&svg=true)](https://ci.appveyor.com/project/ephracis/stoffi-core)
 
 # The Stoffi Player Core
 This is the core of the Stoffi Music Player. It is shared between platforms and contains common stuff such as playlist management, media playback, and cloud integration.
@@ -8,13 +8,8 @@ This is the core of the Stoffi Music Player. It is shared between platforms and 
   1. Fork it
   2. Clone it
   
-        git clone https://github.com/*YOURNAME*/stoffi-player-core.git
+        git clone https://github.com/*YOURNAME*/stoffi-core.git
 
   3. Initialize submodules
   
         git submodule update --init --recursive
-
-  4. Add secret keys
-  
-        cp Services\Keys.tmpl.cs Services\Keys.cs
-        notepad++ Services\Keys.cs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ notifications:
 - provider: Slack
   auth_token:
     secure: ZIZ1ZE+PiJy00kpkOs/50Cgnn1y/U65Hs5xV9eYdyvnDi0tItUUd0y3DnS4l/mld
-  channel: general
+  channel: '#general'
   on_build_success: true
   on_build_failure: true
   on_build_status_changed: true


### PR DESCRIPTION
After changing project name and replacing master branch with develop
branch, some changes need to be made to README. Also, AppVeyor now
requires channel names to include the hash symbol.