### PR TITLE
Add playback service

### DIFF
--- a/Core.Tests/Core.Tests.csproj
+++ b/Core.Tests/Core.Tests.csproj
@@ -48,6 +48,22 @@
       <HintPath>..\packages\Prism.Mvvm.1.1.1\lib\net45\Microsoft.Practices.Prism.SharedInterfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -74,11 +90,15 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Common\StringTest.cs" />
+    <Compile Include="Mocks\MockMediaService.cs" />
     <Compile Include="Mocks\MockResponseHandler.cs" />
     <Compile Include="Mocks\MockSettingsStorage.cs" />
+    <Compile Include="Models\SongTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\SearchServiceTest.cs" />
     <Compile Include="Services\SettingsServiceTest.cs" />
+    <Compile Include="Services\PlaybackServiceTest.cs" />
+    <Compile Include="Services\ContainerTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj">

--- a/Core.Tests/Core.Tests.csproj
+++ b/Core.Tests/Core.Tests.csproj
@@ -49,19 +49,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Core.Tests/Mocks/MockMediaService.cs
+++ b/Core.Tests/Mocks/MockMediaService.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using Stoffi.Core.Enums;
+using Stoffi.Core.Services;
+using Microsoft.Practices.Prism.Mvvm;
+using Stoffi.Core.Models;
+
+namespace Stoffi.Core.Tests.Mocks
+{
+    public class MockMediaService : BindableBase, IMediaService
+    {
+        public TimeSpan CurrentTime { get; set; }
+        public PlaybackQuality PreferedQuality { get; set; }
+        public TimeSpan RemainingTime { get; set; }
+        public PlaybackState State { get; set; }
+        public List<string> CalledMethods = new List<string>();
+
+        public void Pause()
+        {
+            CalledMethods.Add("Pause()");
+        }
+
+        public void Play(Song song = null)
+        {
+            CalledMethods.Add($"Play({song})");
+        }
+    }
+}

--- a/Core.Tests/Models/SongTest.cs
+++ b/Core.Tests/Models/SongTest.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Stoffi.Core.Common;
+using Stoffi.Core.Models;
+
+namespace Stoffi.Core.Tests.Common
+{
+    [TestClass]
+    public class SongTest
+    {
+        [TestMethod]
+        public void PathId_YouTube_ReturnsId()
+        {
+            var song = new Song();
+            song.Path = "stoffi://song/youtube/Test123";
+            Assert.AreEqual("Test123", song.GetPathId());
+        }
+    }
+}

--- a/Core.Tests/Services/ContainerTest.cs
+++ b/Core.Tests/Services/ContainerTest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Stoffi.Core.Services;
+
+namespace Stoffi.Core.Tests.Services
+{
+    [TestClass]
+    public class ContainerTest
+    {
+        [TestMethod]
+        public void Instance_ReturnsSingleton()
+        {
+            var a = Container.Instance;
+            var b = Container.Instance;
+            Assert.AreSame(a, b);
+        }
+    }
+}

--- a/Core.Tests/Services/PlaybackServiceTest.cs
+++ b/Core.Tests/Services/PlaybackServiceTest.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Stoffi.Core.Enums;
+using Stoffi.Core.Models;
+using Stoffi.Core.Services;
+using Stoffi.Core.Tests.Mocks;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Stoffi.Core.Tests.Services
+{
+    [TestClass]
+    public class PlaybackServiceTest
+    {
+        [TestMethod]
+        public void SetSong_NotNull_RaisePropertyChanged()
+        {
+            string firedEvent = null;
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            {
+                firedEvent = e.PropertyName;
+            };
+            service.Song = new Song();
+            Assert.IsNotNull(firedEvent);
+            Assert.AreEqual("Song", firedEvent);
+        }
+
+        [TestMethod]
+        public void SetSong_Same_DontRaisePropertyChanged()
+        {
+            var song = new Song();
+            string firedEvent = null;
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.Song = song;
+            service.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            {
+                firedEvent = e.PropertyName;
+            };
+            service.Song = song;
+            Assert.IsNull(firedEvent);
+        }
+
+        [TestMethod]
+        public void SetState_PlayingWithoutSong_PlayMedia()
+        {
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.State = PlaybackState.Playing;
+            Assert.IsTrue(media.CalledMethods.Contains("Play()"));
+        }
+
+        [TestMethod]
+        public void SetState_PlayingWithSong_PlayMedia()
+        {
+            var song = new Song { Path = "foobar" };
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.Song = song;
+            service.State = PlaybackState.Playing;
+            Assert.IsTrue(media.CalledMethods.Contains("Play(Stoffi.Core.Models.Song)"));
+            Assert.AreEqual(1, media.CalledMethods.Count);
+        }
+
+        [TestMethod]
+        public void SetSong_PausedWithSong_PlayMedia()
+        {
+            var song = new Song();
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.State = PlaybackState.Paused;
+            media.CalledMethods.Clear();
+            service.Song = song;
+            Assert.AreEqual(0, media.CalledMethods.Count);
+        }
+
+        [TestMethod]
+        public void SetSong_LoadingWithSong_PlayMedia()
+        {
+            var song = new Song();
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.State = PlaybackState.Loading;
+            media.CalledMethods.Clear();
+            service.Song = song;
+            Assert.IsTrue(media.CalledMethods.Contains("Play(Stoffi.Core.Models.Song)"));
+            Assert.AreEqual(1, media.CalledMethods.Count);
+        }
+
+        [TestMethod]
+        public void SetSong_Null_PauseMedia()
+        {
+            var media = new MockMediaService();
+            var service = new PlaybackService(media, new SettingsService(new MockSettingsStorage()));
+            service.State = PlaybackState.Playing;
+            service.Song = new Song();
+            media.CalledMethods.Clear();
+            service.Song = null;
+            Assert.IsTrue(media.CalledMethods.Contains("Pause()"));
+            Assert.AreEqual(1, media.CalledMethods.Count);
+        }
+
+        [TestMethod]
+        public async Task ChangeSong_SavesToSettings()
+        {
+            var media = new MockMediaService();
+            var settings = new SettingsService(new MockSettingsStorage());
+            var service = new PlaybackService(media, settings);
+            var song = new Song() { Id = 1337 };
+            service.State = PlaybackState.Playing;
+            service.Song = song;
+            Assert.AreEqual(song, await settings.Read<Song>("PlaybackSong", null));
+        }
+
+        [TestMethod]
+        public async Task Constructor_LoadsSongFromSettings()
+        {
+            var media = new MockMediaService();
+            var settings = new SettingsService(new MockSettingsStorage());
+            var song = new Song() { Id = 1337 };
+            await settings.Write("PlaybackSong", song);
+            var service = new PlaybackService(media, settings);
+            Assert.AreEqual(song, service.Song);
+        }
+
+        [TestMethod]
+        public async Task ChangeState_SavesToSettings()
+        {
+            var media = new MockMediaService();
+            var settings = new SettingsService(new MockSettingsStorage());
+            var service = new PlaybackService(media, settings);
+            service.Song = new Song() { Id = 1337 };
+            service.State = PlaybackState.Loading;
+            Assert.AreEqual(PlaybackState.Loading, await settings.Read<PlaybackState>("PlaybackState", PlaybackState.Paused));
+        }
+
+        [TestMethod]
+        public async Task Constructor_LoadsStateFromSettings()
+        {
+            var media = new MockMediaService();
+            var settings = new SettingsService(new MockSettingsStorage());
+            await settings.Write("PlaybackState", PlaybackState.Loading);
+            var service = new PlaybackService(media, settings);
+            Assert.AreEqual(PlaybackState.Loading, service.State);
+        }
+    }
+}

--- a/Core.Tests/Services/SearchServiceTest.cs
+++ b/Core.Tests/Services/SearchServiceTest.cs
@@ -15,7 +15,7 @@ namespace Stoffi.Core.Tests.Services
         {
             var mockResponseHandler = new MockResponseHandler();
             mockResponseHandler.AddFakeResponse(
-                "http://l.stoffi.io/search.json?q=love&limit=3",
+                "http://l.stoffi.io/search.json?q=love&limit=3&c=songs",
                 "SearchResult_Love.json");
             var httpClient = new HttpClient(mockResponseHandler);
             var searchService = new SearchService(httpClient);
@@ -30,7 +30,7 @@ namespace Stoffi.Core.Tests.Services
         {
             var mockResponseHandler = new MockResponseHandler();
             mockResponseHandler.AddFakeResponse(
-                "http://l.stoffi.io/search.json?q=&limit=3",
+                "http://l.stoffi.io/search.json?q=&limit=3&c=songs",
                 "SearchResult_Empty.json");
             var httpClient = new HttpClient(mockResponseHandler);
             var searchService = new SearchService(httpClient);

--- a/Core.Tests/packages.config
+++ b/Core.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="Prism.Mvvm" version="1.1.1" targetFramework="net46" />
+  <package id="Unity" version="4.0.1" targetFramework="net46" />
 </packages>

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -41,7 +41,14 @@
   <ItemGroup>
     <Compile Include="Common\String.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Enums\PlaybackQuality.cs" />
+    <Compile Include="Enums\PlaybackState.cs" />
+    <Compile Include="Models\Artist.cs" />
+    <Compile Include="Models\Genre.cs" />
+    <Compile Include="Models\Source.cs" />
     <Compile Include="Services\Container.cs" />
+    <Compile Include="Services\IMediaService.cs" />
+    <Compile Include="Services\IPlaybackService.cs" />
     <Compile Include="Services\ISettingsService.cs" />
     <Compile Include="Models\Model.cs" />
     <Compile Include="Models\SearchResult.cs" />
@@ -49,6 +56,7 @@
     <Compile Include="Models\Song.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\ISearchService.cs" />
+    <Compile Include="Services\PlaybackService.cs" />
     <Compile Include="Services\SearchService.cs" />
     <Compile Include="Services\SettingsService.cs" />
   </ItemGroup>

--- a/Core/Enums/PlaybackQuality.cs
+++ b/Core/Enums/PlaybackQuality.cs
@@ -1,0 +1,23 @@
+﻿namespace Stoffi.Core.Enums
+{
+    /// <summary>
+    /// The quality level of a stream.
+    /// </summary>
+    public enum PlaybackQuality
+    {
+        /// <summary>
+        /// The stream is of bad quality.
+        /// </summary>
+        Low,
+
+        /// <summary>
+        /// The stream is of acceptable quality.
+        /// </summary>
+        Medium,
+
+        /// <summary>
+        /// The stream is of great quality.
+        /// </summary>
+        High
+    }
+}

--- a/Core/Enums/PlaybackState.cs
+++ b/Core/Enums/PlaybackState.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stoffi.Core.Enums
+{
+    /// <summary>
+    /// The current state of the playback service.
+    /// </summary>
+    public enum PlaybackState
+    {
+        /// <summary>
+        /// A song is about to be played, possibly buffering the stream.
+        /// </summary>
+        Loading,
+
+        /// <summary>
+        /// A song is currently being played.
+        /// </summary>
+        Playing,
+
+        /// <summary>
+        /// Nothing is being played.
+        /// </summary>
+        Paused
+    }
+}

--- a/Core/Models/Artist.cs
+++ b/Core/Models/Artist.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Practices.Prism.Mvvm;
+
+namespace Stoffi.Core.Models
+{
+    public class Artist : BindableBase
+    {
+        public int Id { get; set; }
+        public string Url { get; set; }
+
+        private string name;
+        public string Name
+        {
+            get { return name; }
+            set { SetProperty(ref name, value); }
+        }
+    }
+}

--- a/Core/Models/Genre.cs
+++ b/Core/Models/Genre.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Practices.Prism.Mvvm;
+
+namespace Stoffi.Core.Models
+{
+    public class Genre : BindableBase
+    {
+        public int Id { get; set; }
+        public string Url { get; set; }
+
+        private string name;
+        public string Name {
+            get { return name; }
+            set { SetProperty(ref name, value); }
+        }
+    }
+}

--- a/Core/Models/Song.cs
+++ b/Core/Models/Song.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,14 +14,108 @@ namespace Stoffi.Core.Models
 	public class Song : Model
 	{
         /// <summary>
+        /// The unique database ID of the song.
+        /// </summary>
+		public int Id { get; set; }
+
+        /// <summary>
         /// The name of the song.
         /// </summary>
         [JsonProperty("title")]
-		public string Name { get; set; }
+        public string Name { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public int Listens { get; set; }
+
+        private ObservableCollection<Source> sources = new ObservableCollection<Source>();
+        public ObservableCollection<Source> Sources
+        {
+            get { return sources; }
+            set { SetProperty(ref sources, value); }
+        }
+
+        private ObservableCollection<Artist> artists = new ObservableCollection<Artist>();
+        public ObservableCollection<Artist> Artists
+        {
+            get { return artists; }
+            set { SetProperty(ref artists, value); }
+        }
+
+        private ObservableCollection<Genre> genres = new ObservableCollection<Genre>();
+        public ObservableCollection<Genre> Genres
+        {
+            get { return genres; }
+            set { SetProperty(ref genres, value); }
+        }
+
+        private string path = null;
+        /// <summary>
+        /// The unique path of the song.
+        /// 
+        /// Expected format: stoffi://&gt;
+        /// For example: stoffi://song/youtube/dQw4w9WgXcQ
+        /// </summary>
+		public string Path
+        {
+            set { path = value;  }
+            get
+            {
+                if (Sources.Count == 0)
+                    return path;
+                return Sources[0].Path;
+            }
+        }
 
         /// <summary>
-        /// The song ID.
+        /// A display name for the artists of the song.
         /// </summary>
-		public int Id { get; set; }
-	}
+        public string Artist
+        {
+            get
+            {
+                if (Artists.Count == 0)
+                    return "DJ Anonymous";
+                return string.Join(" ft. ", Artists.Select(x => x.Name));
+            }
+        }
+
+        static int videoN = 0;
+        static string[] videos = {
+            "dQw4w9WgXcQ", // *rick-roll*
+            "9Riq6IMqXz8", // Vigiland - Pong Dance
+            "Bznxx12Ptl0", // AronChupa - I'm an Albatraoz
+            "60ItHLz5WEA", // Alan Walker - Faded
+            "oyEuk8j8imI", // Justin Beiber - Love Yourself
+            "fyeTJVU4wVo", // Amy Schumer - Girl, You Don't Need Makeup
+            "oeCihv9A3ac", // Eminem - Phenomenal
+            "0AqnCSdkjQ0", // Eminem - Guts Over Fear ft. Sia
+            "enSDiaZJzEM" // Randy - I am LORDE!
+        };
+        public Song()
+        {
+            // TODO: temporary demo feature - fill youtube path
+            if (String.IsNullOrWhiteSpace(path))
+            {
+                var id = videos[videoN % videos.Count()];
+                path = $"stoffi://song/youtube/{id}";
+                videoN++;
+            }
+        }
+
+        /// <summary>
+        /// Gets the ID section of a path.
+        /// </summary>
+        /// <returns>123 for stoffi://resource/backend/123</returns>
+        public string GetPathId()
+        {
+            if (String.IsNullOrWhiteSpace(Path))
+                throw new ArgumentException("Trying to extract ID from null Path");
+            var uri = new Uri(Path);
+            var fields = uri.AbsolutePath.Split('/');
+            if (fields.Length != 3) // first is empty
+                throw new FormatException($"Path '${Path}' is not in format stoffi://<resource>/<backend>/<id>");
+            return fields[2];
+        }
+    }
 }

--- a/Core/Models/Source.cs
+++ b/Core/Models/Source.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Practices.Prism.Mvvm;
+
+namespace Stoffi.Core.Models
+{
+    public class Source : BindableBase
+    {
+        public int Id { get; set; }
+        public string Url { get; set; }
+        public string Name { get; set; }
+        public string ForeignId { get; set; }
+        public string Path { get; set; }
+    }
+}

--- a/Core/Services/IMediaService.cs
+++ b/Core/Services/IMediaService.cs
@@ -1,0 +1,21 @@
+﻿using Stoffi.Core.Enums;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Stoffi.Core.Models;
+
+namespace Stoffi.Core.Services
+{
+    public interface IMediaService : INotifyPropertyChanged
+    {
+        PlaybackState State { get; }
+        TimeSpan CurrentTime { get; set; }
+        TimeSpan RemainingTime { get; }
+        PlaybackQuality PreferedQuality { get; set; }
+        void Play(Song song = null);
+        void Pause();
+    }
+}

--- a/Core/Services/IPlaybackService.cs
+++ b/Core/Services/IPlaybackService.cs
@@ -1,0 +1,14 @@
+﻿using Stoffi.Core.Models;
+using Stoffi.Core.Enums;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace Stoffi.Core.Services
+{
+    public interface IPlaybackService : INotifyPropertyChanged
+    {
+        Song Song { get; set; }
+        ObservableCollection<Song> Upcoming { get; }
+        PlaybackState State { get; set; }
+    }
+}

--- a/Core/Services/PlaybackService.cs
+++ b/Core/Services/PlaybackService.cs
@@ -1,0 +1,119 @@
+﻿using Stoffi.Core.Enums;
+using Stoffi.Core.Models;
+using Microsoft.Practices.Prism.Mvvm;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Stoffi.Core.Services
+{
+    public class PlaybackService : BindableBase, IPlaybackService
+    {
+        private Song song;
+        /// <summary>
+        /// The currently loaded song.
+        /// </summary>
+        public Song Song
+        {
+            get { return song; }
+            set { SetProperty<Song>(ref song, value); }
+        }
+
+        private PlaybackState state = PlaybackState.Paused;
+        /// <summary>
+        /// The current state of the playback service.
+        /// </summary>
+        public PlaybackState State
+        {
+            get { return state; }
+            set {
+                SetProperty<PlaybackState>(ref state, value);
+            }
+        }
+        
+        /// <summary>
+        /// A list of upcoming songs.
+        /// </summary>
+        public ObservableCollection<Song> Upcoming { get; private set; }
+
+        /// <summary>
+        /// Platform specific code for managing media.
+        /// </summary>
+        private IMediaService mediaService;
+
+        private ISettingsService settings;
+
+        public PlaybackService(IMediaService mediaService, ISettingsService settingsService)
+        {
+            Upcoming = new ObservableCollection<Song>();
+            this.mediaService = mediaService;
+            this.settings = settingsService;
+            PropertyChanged += PlaybackService_PropertyChanged;
+            LoadSettings();
+        }
+
+        /// <summary>
+        /// Acts on changes in the properties of this service.
+        /// </summary>
+        /// <param name="sender">The sender of the event</param>
+        /// <param name="e">The event data</param>
+        private void PlaybackService_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "State":
+                    StateChanged();
+                    break;
+
+                case "Song":
+                    SongChanged();
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Acts on the media service according to a recent change in state.
+        /// </summary>
+        private void StateChanged()
+        {
+            switch (State)
+            {
+                case PlaybackState.Loading:
+                    break;
+
+                case PlaybackState.Playing:
+                    mediaService.Play(Song);
+                    break;
+
+                case PlaybackState.Paused:
+                    mediaService.Pause();
+                    break;
+
+                default:
+                    break;
+            }
+            settings.Write("PlaybackState", State);
+        }
+
+        /// <summary>
+        /// Acts on the media service according to a recent change in state.
+        /// </summary>
+        private void SongChanged()
+        {
+            if (Song == null)
+                mediaService.Pause();
+            else if (State != PlaybackState.Paused)
+                mediaService.Play(Song);
+            settings.Write("PlaybackSong", Song);
+        }
+
+        private async Task LoadSettings()
+        {
+            Song = await settings.Read<Song>("PlaybackSong", null);
+            State = await settings.Read<PlaybackState>("PlaybackState", state);
+        }
+    }
+}

--- a/Core/Services/SearchService.cs
+++ b/Core/Services/SearchService.cs
@@ -40,7 +40,7 @@ namespace Stoffi.Core.Services
         /// <returns>An object describing the search result</returns>
         public async Task<SearchResult> GetFilteredSongsAsync(string searchQuery, int maxResults)
         {
-            var uri = new Uri($"{Constants.ServerAddress}/search.json?q={searchQuery}&limit={maxResults}");
+            var uri = new Uri($"{Constants.ServerAddress}/search.json?q={searchQuery}&limit={maxResults}&c=songs");
             var response = await httpClient.GetAsync(uri);
             response.EnsureSuccessStatusCode();
             var responseContent = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
- Playback service for managing playback state (Core)
- Media service for managing youtube playback (Platform)
- New method `Song#GetPathId` extracts the ID section of a path.
- Search service will now filter on songs.
- `Path` property of `Song` is set to a random YouTube video if null.
- More models: `Artist`, `Genre`, `Source`.
- Expanded `Song` meta data.